### PR TITLE
Wrap budget_name output with length check

### DIFF
--- a/modules/budget/outputs.tf
+++ b/modules/budget/outputs.tf
@@ -16,5 +16,5 @@
 
 output "name" {
   description = "Resource name of the budget. Values are of the form `billingAccounts/{billingAccountId}/budgets/{budgetId}.`"
-  value       = var.create_budget ? google_billing_budget.budget[0].name : ""
+  value       = length(google_billing_budget.budget) > 0 ? google_billing_budget.budget[0].name : ""
 }


### PR DESCRIPTION
When running `terraform plan -refresh-only` and `var.create_budget` turns from `false` to `true` (via passing a non-null `budget_amount` in [`create_budget = var.budget_amount != null`](https://github.com/terraform-google-modules/terraform-google-project-factory/blob/master/main.tf#L90) this fails with the message:

```
│ Error: Invalid index
│
│   on .terraform/modules/project.project-factory/modules/budget/outputs.tf line 19, in output "name":
│   19:   value       = var.create_budget ? google_billing_budget.budget[0].name : ""
│     ├────────────────
│     │ google_billing_budget.budget is empty tuple
│
│ The given key does not identify an element in this collection value: the
│ collection has no elements.
```

Seems related to https://github.com/hashicorp/terraform/issues/23222

Run on: Terraform v1.0.11 on darwin_amd64